### PR TITLE
Improve regex to search in /etc/hosts

### DIFF
--- a/plugins/compose.sh
+++ b/plugins/compose.sh
@@ -145,7 +145,7 @@ Compose::CheckLocalHostName()
     do
         Log "Check if $VHOST is in /etc/hosts"
         try {
-          grep "127.0.0.1 $VHOST" /etc/hosts > /dev/null 2>&1
+          grep "127.0.0.1[[:blank:]]*$VHOST" /etc/hosts > /dev/null 2>&1
           Log "127.0.0.1 $VHOST is in /etc/hosts"
         } catch {
           Log "127.0.0.1 $VHOST is not in /etc/hosts"


### PR DESCRIPTION
Dans mon /etc/hosts j'avais de plusieurs espaces entre l'ip et le domaines, du coup il me propose d'ajouter des domaines qui y sont déjà