### PR TITLE
Fix phpmyadmin config file becoming a folder instead of a file

### DIFF
--- a/plugins/phpmyadmin.sh
+++ b/plugins/phpmyadmin.sh
@@ -43,6 +43,12 @@ PhpMyAdmin::Execute()
         Log "No phpmyadmin container to remove"
     }
 
+    # Test if the /tmp/phpmyadmin/config.user.inc.php is a folder
+    if [ -d /tmp/phpmyadmin/config.user.inc.php ]; then
+        rm -rf /tmp/phpmyadmin/config.user.inc.php
+        touch /tmp/phpmyadmin/config.user.inc.php
+    fi
+
     templateDir=/tmp/templates
     if [ "$OSTYPE" != 'linux-gnu' ]
     then


### PR DESCRIPTION
Sometimes the /tmp/phpmyadmin/config.user.inc.php becomes a folder and need to be reset as a file